### PR TITLE
Fixes embed functionality for brightcove media items in experience editor

### DIFF
--- a/src/Brightcove.MediaFramework.Brightcove/Pipelines/MediaGenerateMarkup/GenerateMarkup.cs
+++ b/src/Brightcove.MediaFramework.Brightcove/Pipelines/MediaGenerateMarkup/GenerateMarkup.cs
@@ -78,6 +78,12 @@ namespace Brightcove.MediaFramework.Brightcove.Pipelines.MediaGenerateMarkup
     {
       var resource = isJs ? "index.min.js" : $"index.html?videoId={args.MediaItem[BrightcovePlayerParameters.MediaId]}";
       var url = new UrlString($"//players.brightcove.net/{args.AccountItem[BrightcovePlayerParameters.PublisherId]}/{args.PlayerItem[BrightcovePlayerParameters.PlayerId]}_default/{resource}");
+
+      foreach (string arg in args.Properties.Collection)
+      {
+          url[arg] = args.Properties.Collection[arg];
+      }
+
       return url.ToString();
     }
 
@@ -112,6 +118,7 @@ namespace Brightcove.MediaFramework.Brightcove.Pipelines.MediaGenerateMarkup
                 <video data-video-id='{args.MediaItem[BrightcovePlayerParameters.MediaId]}'
                   data-account='{args.AccountItem[BrightcovePlayerParameters.PublisherId]}' 
 	                data-player='{args.PlayerItem[BrightcovePlayerParameters.PlayerId]}' 
+                  data-item-id='{args.Properties.ItemId}'
 	                data-embed='default' 
 	                data-application-id 
 	                class='video-js' 

--- a/src/Sitecore.MediaFramework/Commands/EmbedMedia.cs
+++ b/src/Sitecore.MediaFramework/Commands/EmbedMedia.cs
@@ -1,7 +1,7 @@
 ﻿namespace Sitecore.MediaFramework.Commands
 {
   using System;
-
+  using System.Text.RegularExpressions;
   using Sitecore.Data;
   using Sitecore.Diagnostics;
   using Sitecore.Layouts;
@@ -13,6 +13,10 @@
   [Serializable]
   public class EmbedMedia : Command
   {
+    private const string GuidRegex = @"[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?";
+    private const string ItemIdGroupName = "itemid";
+    private static readonly Regex ItemIdRegex = new Regex(@"item(\-)?[I|i]d=(\')?(?'" + ItemIdGroupName + "'" + GuidRegex + ")");
+
     public override void Execute(CommandContext context)
     {
       Context.ClientPage.Start(this, "Run", context.Parameters);
@@ -77,13 +81,12 @@
 
           UrlString url = new UrlString(this.GetParameters(args.Result));
 
-          string itemId = url[Constants.PlayerParameters.ItemId];
+          var itemId = GetItemId(args.Result);
 
           url.Remove(Constants.PlayerParameters.ItemId);
 
-          rendering.Datasource = new ID(itemId).ToString();
+          rendering.Datasource = itemId.ToString();
           rendering.Parameters = url.ToString();
-
 
           parsedLayout.Devices[deviceIndex] = device;
           var updatedLayout = parsedLayout.ToXml();
@@ -92,6 +95,19 @@
           SheerResponse.Eval("window.parent.Sitecore.PageModes.ChromeManager.handleMessage('chrome:rendering:propertiescompleted');");
         }
       }
+    }
+
+    private ID GetItemId(string embedCode)
+    {
+        if (!ItemIdRegex.IsMatch(embedCode))
+        {
+            throw new InvalidOperationException("The generated embed code is invalid");
+        }
+
+        var match = ItemIdRegex.Match(embedCode);
+        var id = ID.Parse(match.Groups[ItemIdGroupName].Value);
+
+        return id;
     }
 
     protected virtual string GetParameters(string markup)


### PR DESCRIPTION
Fixes embed functionality for brightcove media items in experience editor

Forces custom markup generator to pass Item ID through to command handler (EmbedMedia). Further work may be done here to reduce/remove dependency on HTML Agility Pack.

Signed-off-by: John Sedlak <john.sedlak@outlook.com>